### PR TITLE
oops, was munging the source .pm document (zeroing its content) rather than re-munging the destination file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Dist-Zilla-Plugin-ReadmeAnyFromPod
 
 {{$NEXT}}
+    - fix handling of case where readme contents are regenerated after the
+      source .pm is altered after we initially looked at it
 
 0.132973  2013-10-23 17:15:29 America/Los_Angeles
     - now using FileGatherer, FileMunger and AfterBuild phases rather than

--- a/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
@@ -230,7 +230,7 @@ sub munge_file {
             if ($newcontent ne $plugin->_last_source_content)
             {
                 $plugin->log('someone tried to munge ' . $source_file->name . ' after we read from it. Making modifications again...');
-                $plugin->munge_file($self);
+                $plugin->munge_file($file);
             }
         });
 

--- a/t/too-soon.t
+++ b/t/too-soon.t
@@ -51,6 +51,18 @@ MODULE
         supersetof('[ReadmeAnyFromPod] someone tried to munge lib/Foo.pm after we read from it. Making modifications again...'),
         '...but includes a useful warning about plugin ordering',
     );
+
+    my $build_dir = $tzil->tempdir->subdir('build');
+
+    my $dist_file = path($build_dir, "README.md");
+    ok(-e $dist_file, "README.md created in dist");
+
+    my $content = $dist_file->slurp_utf8;
+    like($content, qr/=head1 NAME/, 'contains headers added by PodWeaver');
+
+    my $pm_content = path($build_dir, 'lib/Foo.pm')->slurp_utf8;
+
+    like($pm_content, qr/=head1 NAME/, 'PodWeaver added a NAME header to document');
 }
 
 {
@@ -81,10 +93,9 @@ MODULE
     ok(-e $dist_file, "README.md created in dist");
 
     my $content = $dist_file->slurp_utf8;
-#print "### content of README is -- $content -- \n";
+    like($content, qr/=head1 NAME/, 'contains headers added by PodWeaver');
 
     my $pm_content = path($build_dir, 'lib/Foo.pm')->slurp_utf8;
-#print "### content of .pm is -- $pm_content -- \n";
 
     like($pm_content, qr/=head1 NAME/, 'PodWeaver added a NAME header to document');
 }


### PR DESCRIPTION
My bad! I discovered this as soon as I built a dist with another plugin loaded later that added a header to the main .pm file.  eating dogfood pays off ;)

More tests are added for the content of both source and destination files.
