### PR TITLE
Load runtime dependencies dynamically

### DIFF
--- a/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
@@ -11,8 +11,6 @@ use Moose::Autobox;
 use Moose::Util::TypeConstraints qw(enum);
 use Moose;
 use MooseX::Has::Sugar;
-use PPI::Document;
-use PPI::Token::Pod;
 use Path::Tiny 0.004;
 use Scalar::Util 'blessed';
 
@@ -304,6 +302,8 @@ sub _get_source_content {
 sub _get_source_pod {
     my ($self) = shift;
     my $source_content = $self->_get_source_content();
+
+    require PPI::Document;
 
     my $doc = PPI::Document->new(\$source_content);
     my $pod_elems = $doc->find('PPI::Token::Pod');


### PR DESCRIPTION
This patch delays loading of Pod::Simple::HTML, Pod::Simple::Text and PPI::Document to the moment when they are needed.

See miyagawa/Dist-Milla#24 for the rationale and expected benefits.

Note that I've not been able to fully test the patches with `dzil test` because `[@Author::RTHOMPSON]` failed to install: see [RT#96697](https://rt.cpan.org/Ticket/Display.html?id=96697).
