### PR TITLE
Specify to indexers to ignore corpus dir

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,3 +8,6 @@ copyright_holder = Ryan C. Thompson
 synopsis_is_perl_code = false
 
 ; authordep Pod::Weaver::PluginBundle::Author::RTHOMPSON
+
+[MetaNoIndex]
+directory = corpus


### PR DESCRIPTION
Metacpan shows these files as "examples" when they are really just used for testing.