### PR TITLE
Add provides to META.yml

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,5 +9,7 @@ synopsis_is_perl_code = false
 
 ; authordep Pod::Weaver::PluginBundle::Author::RTHOMPSON
 
+[MetaProvides::Package]
+
 [MetaNoIndex]
 directory = corpus


### PR DESCRIPTION
Howdy, I got your module this month as part of the CPAN Pull Request Challenge.  It looked like you're following good practices pretty consistently, so I didn't see a lot of room for improvement.  This is a trivial change to have Dist::Zilla create the "provides" section in the META.yml ( http://search.cpan.org/~dagolden/CPAN-Meta-2.150005/lib/CPAN/Meta/Spec.pm#provides ).  Note it needs the Dist::Zilla::Plugin::MetaProvides package to be installed to successfully "dzil build".