### PR TITLE
expect decoded characters via the new PPI role

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Dist-Zilla-Plugin-ReadmeAnyFromPod
 
 {{$NEXT}}
+    - do not decode the already-decoded strings from PPI, now that
+      Dist::Zilla::Role::PPI is fixed (in 6.003)
 
 0.161150  2016-04-24 10:10:10-07:00 America/Los_Angeles
     - Update for Dist::Zilla v6 compatibility.

--- a/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
@@ -379,7 +379,10 @@ sub _get_source_pod {
         $pod_content .= PPI::Token::Pod->merge(@$pod_elems);
     }
 
-    if ((my $encoding = $self->_get_source_encoding) ne 'raw') {
+    if ((my $encoding = $self->_get_source_encoding) ne 'raw'
+            and not eval { Dist::Zilla::Role::PPI->VERSION('6.003') }
+    ) {
+        # older Dist::Zilla::Role::PPI passes encoded content to PPI
         require Encode;
         $pod_content = Encode::decode($encoding, $pod_content);
     }


### PR DESCRIPTION
Dist::Zilla::Role::PPI was just changed to pass/receive decoded characters
to/from PPI, rather than encoded bytes.