### PR TITLE
Add Pod::Markdown::Github as available type

### DIFF
--- a/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
@@ -56,6 +56,20 @@ our $_types = {
             return $content;
         },
     },
+    github_markdown => {
+        filename => 'README.mkdn',
+        parser => sub {
+            my $pod = $_[0];
+
+            require Pod::Markdown::Github;
+            Pod::Markdown->VERSION('0.01');
+            my $parser = Pod::Markdown::Github->new();
+            $parser->output_string( \my $content );
+            $parser->parse_characters(1);
+            $parser->parse_string_document($pod);
+            return $content;
+        },
+    },
     html => {
         filename => 'README.html',
         parser => sub {

--- a/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
@@ -57,7 +57,7 @@ our $_types = {
         },
     },
     github_markdown => {
-        filename => 'README.mkdn',
+        filename => 'README.md',
         parser => sub {
             my $pod = $_[0];
 


### PR DESCRIPTION
i like the syntax highlighting on Github, but sadly Pod::Markdown does not enclose the paragraph in ```.

Pod::Markdown::Github adds those ``` with 'perl' as language to the syntax block.
