### PR TITLE
Corrected log message

### DIFF
--- a/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
+++ b/lib/Dist/Zilla/Plugin/ReadmeAnyFromPod.pm
@@ -348,7 +348,7 @@ sub _create_readme {
 
         my $destination_file = path($self->zilla->root)->child($filename);
         if (-e $destination_file) {
-            $self->log("overriding $filename in root");
+            $self->log("overwriting $filename in root");
         }
         my $encoding = $self->_get_source_encoding();
         $destination_file->spew_raw(


### PR DESCRIPTION
I just fell over this log message, which I find a tad confusing.

The log message states: 

```
[MarkdownInRoot] overriding README.md in root
```

When it actually overwrites/replaces.

IMHO the log message should read:

```
[MarkdownInRoot] overwriting README.md in root
```

1. [Definition of override in Merriam-Webster](https://www.merriam-webster.com/dictionary/override)
2. [Definition of overwrite in Merriam-Webster](https://www.merriam-webster.com/dictionary/overwrite)
3. [Article on the term overwrite from Wikipedia (computer science)](https://en.wikipedia.org/wiki/Overwriting_(computer_science))

The definition of overwrite in Merriam-Webster is not so clear, so I have added the Wikipedia definition also.